### PR TITLE
[pr] bugfix/bogus-quit-detected

### DIFF
--- a/lib/server/client_stream_processor.js
+++ b/lib/server/client_stream_processor.js
@@ -122,7 +122,7 @@ class ClientStreamProcessor extends Transform {
             if(!fillBufferWithData()) {
 
                 // Quit?
-                if (data[data.length - 1] === CMD_QUIT) {
+                if (!readState.didParseCmd && data[data.length - 1] === CMD_QUIT) {
                     this.push('q');
                 }
 

--- a/test/protocol.js
+++ b/test/protocol.js
@@ -156,6 +156,7 @@ describe("Protocol", () => {
                         // Insert 'q' character ('Quit' command) into the GUID, to catch subtle protocol errors when packet size is 1
                         if(test.packetSize === 1) {
                             test.data.guid[test.data.guid.length - 1] = 'q'.charCodeAt(0);
+                            test.data.guid[0] = 'q'.charCodeAt(0);
                         }
 
                         const buf = Buffer.from(

--- a/test/protocol.js
+++ b/test/protocol.js
@@ -153,6 +153,11 @@ describe("Protocol", () => {
 
                 tests.forEach(function (test) {
                     it(`should store ${test.ext} data with a (${test.cmd}) command (client write packet size = ${test.packetSize})`, () => {
+                        // Insert 'q' character ('Quit' command) into the GUID, to catch subtle protocol errors when packet size is 1
+                        if(test.packetSize === 1) {
+                            test.data.guid[test.data.guid.length - 1] = 113;
+                        }
+
                         const buf = Buffer.from(
                             encodeCommand(cmd.transactionStart, test.data.guid, test.data.hash) +
                             encodeCommand(test.cmd, null, null, test.data[test.ext]) +

--- a/test/protocol.js
+++ b/test/protocol.js
@@ -155,8 +155,7 @@ describe("Protocol", () => {
                     it(`should store ${test.ext} data with a (${test.cmd}) command (client write packet size = ${test.packetSize})`, () => {
                         // Insert 'q' character ('Quit' command) into the GUID, to catch subtle protocol errors when packet size is 1
                         if(test.packetSize === 1) {
-                            test.data.guid[test.data.guid.length - 1] = 'q'.charCodeAt(0);
-                            test.data.guid[0] = 'q'.charCodeAt(0);
+                            test.data.guid[0] = test.data.guid[test.data.guid.length - 1] = 'q'.charCodeAt(0);
                         }
 
                         const buf = Buffer.from(

--- a/test/protocol.js
+++ b/test/protocol.js
@@ -155,7 +155,7 @@ describe("Protocol", () => {
                     it(`should store ${test.ext} data with a (${test.cmd}) command (client write packet size = ${test.packetSize})`, () => {
                         // Insert 'q' character ('Quit' command) into the GUID, to catch subtle protocol errors when packet size is 1
                         if(test.packetSize === 1) {
-                            test.data.guid[test.data.guid.length - 1] = 113;
+                            test.data.guid[test.data.guid.length - 1] = 'q'.charCodeAt(0);
                         }
 
                         const buf = Buffer.from(


### PR DESCRIPTION
Fixed bug where a ‘q’ character is mis-interpreted as a quit command, if that character was received as a single packet in the middle of reading data for another command.